### PR TITLE
docs: optimize auth specification

### DIFF
--- a/docs/auth/auth-specification.md
+++ b/docs/auth/auth-specification.md
@@ -59,3 +59,24 @@ sequenceDiagram
     API-->>BFF: 業務データを返却
     BFF-->>Browser: フロントエンド向けにデータを返却
 ```
+
+## 4. BFFの実装ガイドライン (Spring Boot 4.x / Kotlin 2.4.x / WebFlux)
+
+Cline による実装時は、以下の標準的なアプローチを採用すること。独自に複雑なフィルターやトークンパース処理を実装しないこと。また、Java風の `Mono`/`Flux` を直接操作するコードは極力避け、**Kotlin コルーチン (`suspend` 関数) と Kotlin DSL** を積極的に活用すること。
+
+### 4.1. OIDCログインとセッション管理
+- `spring-boot-starter-oauth2-client` を利用し、Keycloak との OIDC 連携を行う。
+- セキュリティ設定は、Spring Security の **Kotlin DSL (`ServerHttpSecurity.invoke { ... }`)** を用いて記述し、`oauth2Login { }` を有効化する。
+- 取得したトークンは Spring Security の標準機能によって WebSession (BFF側) に保持させる。当面はインメモリセッションとし、Redis等は必要になった段階で導入する。
+- セッション Cookie の属性は、原則 `application.yml` の `server.reactive.session.cookie.*` プロパティで設定する。
+  - `http-only: true`
+  - `secure: true` (ローカル開発環境の HTTP 通信時はブラウザ仕様に応じて適宜オフにするか、localhost を用いる)
+  - `same-site: strict`
+
+### 4.2. Token Relay (API呼び出し時のトークン付与)
+- APIサーバーへの通信には、リアクティブな `WebClient` を使用する。
+- リクエストヘッダへのアクセストークン（Bearer）付与、および有効期限切れ時のリフレッシュトークンを用いた自動再取得は、Spring Security が提供する `ServerOAuth2AuthorizedClientExchangeFilterFunction` を `WebClient` に組み込むことで実現し、自作のロジックは極力排除する。
+- `WebClient` の呼び出し時は、`awaitExchange()` や `awaitBody()` などの **コルーチン拡張関数** を使用し、非同期処理を同期的に（フラットに）記述すること。
+
+### 4.3. フロントエンドとの通信境界 (CORS)
+- Nuxt と BFF が別ポートで動くローカル開発環境において Cookie をやり取りするため、BFF 側で適切な CORS 設定（`Allow-Credentials: true` および `Allowed-Origins` の指定）を行うこと。これも Kotlin DSL (`cors { }`) を用いて設定する。


### PR DESCRIPTION
## 📌 概要
既存の `docs/auth/auth-specification.md` に、本プロジェクトの技術スタック（Spring Boot 4.0.6 / Kotlin 2.4.0 / WebFlux）に最適化した「BFFの実装ガイドライン」を追記しました。
あわせて、全体設計憲法である `architecture.md` (`.clinerules`) の「厳格な制約事項」に、ブラウザでのJWT保持禁止と詳細仕様へのリンクを追記しています。

これにより、Cline（AI）が今後の認証・API連携実装において、Java風の古い `Mono`/`Flux` コードやネストの深いリアクティブコードを生成するのを防ぎ、Kotlin DSLや `suspend` 関数（コルーチン）を用いたモダンでクリーンなコードを迷わず選択できるようにルールを整備しました。

## 📐 関連するIssue・設計
- Fixes #33
- 関連ドキュメント: `docs/auth-specification.md`, `architecture.md`

## 🛠️ 主な変更内容
- [x] `docs/auth-specification.md` へ「4. BFFの実装ガイドライン」を追記
  - Spring Security の Kotlin DSL (`ServerHttpSecurity.invoke`) を用いた OIDC ログインおよびインメモリセッション管理の方針を明記
  - `ServerOAuth2AuthorizedClientExchangeFilterFunction` を組み込んだ `WebClient` と、コルーチン拡張関数（`awaitBody()` 等）による Token Relay の実装方針を定義
  - フロントエンド（Nuxt）とのクロスドメイン通信を見据えた CORS 設定（Kotlin DSL）の方針を追記
- [x] `architecture.md` （`.clinerules`）の更新
  - 「2. 厳格な制約事項」に、ブラウザ側でのJWT露出禁止と、詳細仕様（`docs/auth-specification.md`）への参照リンクを追記

## 🧪 動作確認・テスト結果
- [x] 修正したマークダウンファイルが、エディタおよびGitHub上のプレビューで正しくレンダリングされ、構文に問題がないことを確認

## 📸 スクリーンショット / ログ（任意）
<details>
<summary>ログを展開</summary>

```text
（特になし。）
```
</details>

## 💡 備考・注意点
本PRのマージ以降、Clineを用いた認証・API連携周りのコーディングは、すべて今回定義したコルーチンベースのガイドラインが適用されます。これにより、自作の複雑なフィルターやトークンパース処理といった不要なロジックの混入を防ぎ、Spring標準の堅牢なレールの恩恵を受けられるようになります。